### PR TITLE
Static Sine Wave Polish

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,10 +4,23 @@ import SVGWave from './SVGWave';
 import './App.css';
 import 'rc-slider/assets/index.css';
 
+const minStroke = 1;
+const maxStroke = 10;
+
+const minPeriodWidth = 5;
+const maxPeriodWidth = 100;
+
+const minAmplitude = 5;
+const maxAmplitude = 100;
+
 class App extends Component {
   constructor(props) {
     super(props);
-    this.state = { strokeWidth: 1 };
+    this.state = {
+      strokeWidth: minStroke,
+      periodWidth: minPeriodWidth,
+      amplitude: minAmplitude,
+    };
   }
 
   handleAmplitudeChange(val) {
@@ -29,20 +42,32 @@ class App extends Component {
         periodWidth={this.state.periodWidth}
         width={this.state.width}
         amplitude={this.state.amplitude}
-        />;
+      />;
     return (
       <div className="App">
         {svg}
         <div style={{ padding: 50 }}>
           <br></br>
           Stroke
-          <Slider onChange={this.handleStrokeChange.bind(this)} />
+          <Slider
+            min={minStroke}
+            max={maxStroke}
+            onChange={this.handleStrokeChange.bind(this)}
+          />
           <br></br>
           Height
-          <Slider onChange={this.handleAmplitudeChange.bind(this)} />
+          <Slider
+            min={minAmplitude}
+            max={maxAmplitude}
+            onChange={this.handleAmplitudeChange.bind(this)}
+          />
           <br></br>
           Width
-          <Slider onChange={this.handleWidthChange.bind(this)} />
+          <Slider
+            min={minPeriodWidth}
+            max={maxPeriodWidth}
+            onChange={this.handleWidthChange.bind(this)}
+          />
         </div>
       </div>
     );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,7 +5,7 @@ import './App.css';
 import 'rc-slider/assets/index.css';
 
 const minStroke = 1;
-const maxStroke = 10;
+const maxStroke = 5;
 
 const minPeriodWidth = 5;
 const maxPeriodWidth = 100;

--- a/src/SVGWave.jsx
+++ b/src/SVGWave.jsx
@@ -1,29 +1,29 @@
 import React, { Component } from 'react';
 
-/**
- * Properties:
- *  - number of cycles
- *  - offset
- *  - color
- *  - amplitude
- *  - cycle-width
- */
-
 class SVGWave extends Component {
   render() {
-    const height = this.props.height ? this.props.height : 200;
-    const width = this.props.width ? this.props.width : 200;
-    const strokeWidth = this.props.strokeWidth ? this.props.strokeWidth : 1;
-    const startX = 0;
-    const startY = height / 2;
+    // Use the same padding for x & y
     const amplitude = this.props.amplitude ? this.props.amplitude : 50;
+    const padding = this.props.padding ? this.props.padding : 2;
+    const height = amplitude * 2 + (padding * 2);
     const periodWidth = this.props.periodWidth ? this.props.periodWidth : 80;
+    const strokeWidth = this.props.strokeWidth ? this.props.strokeWidth : 1;
+    const width = (periodWidth * 2) + (padding * 2) + (strokeWidth * 2);
+    const startX = 0 + padding + strokeWidth;
+    const startY = height / 2;
+
+    // 1st control pt
     const dx1 = startX;
     const dy1 = startY + amplitude;
-    const dx = dx1 + periodWidth; // Destination
-    const dy = startY; // Destination
+
+    // Destination
+    const dx = startX + periodWidth;
+    const dy = startY;
+
+    // 2nd control pt
     const dx2 = dx;
     const dy2 = dy1;
+
     const dProp =
       `M
       ${startX} ${startY}
@@ -32,10 +32,11 @@ class SVGWave extends Component {
       ${dx2} ${dy2}
       ${dx} ${dy}
       S
-      ${dx * 2} ${startY + (startY - dy1)}
-      ${dx * 2} ${startY}`;
+      ${dx + periodWidth} ${startY + (startY - dy1)}
+      ${dx + periodWidth} ${startY}`;
     return (
       <svg height={height} width={width}>
+        <rect height={height} width={width} stroke="black" fill-opacity={0.0}/>
         <path
           d={dProp}
           stroke="black"


### PR DESCRIPTION
# Summary
This polishes the existing `SVGSineWave` react component and associated sliders. Specifically: 

- `SVGWave` supports padding
- `SVGWave` has a dynamically-sized frame around it 
- Associated sliders have limited numbers
- App context explicitly sets default values