### PR TITLE
Support numCycles in Wave

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ class App extends Component {
           React SVG Wave
         </header>
         <div style={{ margin: 10 }}>
-          <SVGWave numCycles={1}/>
+          <SVGWave/>
         </div>
       </div >
     );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ class App extends Component {
           React SVG Wave
         </header>
         <div style={{ margin: 10 }}>
-          <SVGWave/>
+          <SVGWave numCycles={1}/>
         </div>
       </div >
     );

--- a/src/SVGWave.css
+++ b/src/SVGWave.css
@@ -8,14 +8,14 @@
 }
 
 .data-pane {
-  float: right;
+  float: left;
   padding: 5px;
   width: 25%;
   border: black;
   border-width: 1px;
 }
 .content-pane {
-  float: left;
+  float: none;
   padding: 5px;
   width: 30%;
   border: black;

--- a/src/SVGWave.jsx
+++ b/src/SVGWave.jsx
@@ -13,6 +13,9 @@ const maxPeriodWidth = 150;
 const minAmplitude = 50;
 const maxAmplitude = 150;
 
+const minCycles = 1;
+const maxCycles = 7;
+
 class SVGWave extends Component {
   constructor(props) {
     super(props);
@@ -21,7 +24,7 @@ class SVGWave extends Component {
       strokeWidth: minStroke,
       periodWidth: minPeriodWidth,
       amplitude: minAmplitude,
-      numCycles: this.props.numCycles ? this.props.numCycles : 0,
+      numCycles: minCycles,
     };
   }
 
@@ -40,14 +43,14 @@ class SVGWave extends Component {
   handleCyclesChange(val) {
     this.setState({ numCycles: val });
   }
-  
+
   render() {
 
     const amplitude = this.state.amplitude;
     const height = amplitude * 2;
     const periodWidth = this.state.periodWidth;
     const strokeWidth = this.state.strokeWidth;
-    const width = (periodWidth * (this.state.numCycles + 1));
+    const width = (periodWidth * (this.state.numCycles));
     const startX = 0;
     const startY = height / 2;
 
@@ -67,18 +70,14 @@ class SVGWave extends Component {
 
     const numCycles = this.state.numCycles;
 
-    let suffix =
-      `S
-      ${dx + periodWidth} ${startY + (startY - dy1)}
-      ${dx + periodWidth} ${startY}`;
-    for (let i = 0; i < numCycles; i++) {
-      let thisY = (i % 2) ? dy1 : startY + (startY - dy1);
-      if (i > 0) {
-        suffix += `S ${dx + ((i + 1) * periodWidth)} ${thisY} ${dx + (periodWidth * (i + 1))} ${startY}`;
-      }
+    let suffix = '';
 
+    // The first cycle doesn't require a suffix
+    for (let i = 1; i < numCycles; i++) {
+      // Every other cycle needs inverted control points
+      let thisY = (i % 2) ? startY + (startY - dy1) : dy1;
+      suffix += `S ${dx + (i  * periodWidth)} ${thisY} ${dx + (periodWidth * i)} ${startY}`;
     }
-
 
     const dProp =
       `M
@@ -112,8 +111,8 @@ class SVGWave extends Component {
           />
           cycles
           <Slider
-            min={1}
-            max={15}
+            min={minCycles}
+            max={maxCycles}
             onChange={this.handleCyclesChange.bind(this)}
           />
         </div>

--- a/src/SVGWave.jsx
+++ b/src/SVGWave.jsx
@@ -21,6 +21,7 @@ class SVGWave extends Component {
       strokeWidth: minStroke,
       periodWidth: minPeriodWidth,
       amplitude: minAmplitude,
+      numCycles: this.props.numCycles ? this.props.numCycles : 0,
     };
   }
 
@@ -35,15 +36,19 @@ class SVGWave extends Component {
   handleStrokeChange(val) {
     this.setState({ strokeWidth: val });
   }
+
+  handleCyclesChange(val) {
+    this.setState({ numCycles: val });
+  }
+  
   render() {
-    const padding = 2;
 
     const amplitude = this.state.amplitude;
-    const height = amplitude * 2 + (padding * 2);
+    const height = amplitude * 2;
     const periodWidth = this.state.periodWidth;
     const strokeWidth = this.state.strokeWidth;
-    const width = (periodWidth * 2) + (padding * 2) + (strokeWidth * 2);
-    const startX = 0 + padding + strokeWidth;
+    const width = (periodWidth * (this.state.numCycles + 1));
+    const startX = 0;
     const startY = height / 2;
 
     // 1st control pt
@@ -60,6 +65,21 @@ class SVGWave extends Component {
 
     const metadata = this.state;
 
+    const numCycles = this.state.numCycles;
+
+    let suffix =
+      `S
+      ${dx + periodWidth} ${startY + (startY - dy1)}
+      ${dx + periodWidth} ${startY}`;
+    for (let i = 0; i < numCycles; i++) {
+      let thisY = (i % 2) ? dy1 : startY + (startY - dy1);
+      if (i > 0) {
+        suffix += `S ${dx + ((i + 1) * periodWidth)} ${thisY} ${dx + (periodWidth * (i + 1))} ${startY}`;
+      }
+
+    }
+
+
     const dProp =
       `M
       ${startX} ${startY}
@@ -67,9 +87,7 @@ class SVGWave extends Component {
       ${dx1} ${dy1}
       ${dx2} ${dy2}
       ${dx} ${dy}
-      S
-      ${dx + periodWidth} ${startY + (startY - dy1)}
-      ${dx + periodWidth} ${startY}`;
+      ${suffix}`;
     return (
       // Need to return:
       <div className="container">
@@ -80,19 +98,23 @@ class SVGWave extends Component {
             max={maxStroke}
             onChange={this.handleStrokeChange.bind(this)}
           />
-          <br></br>
           height
           <Slider
             min={minAmplitude}
             max={maxAmplitude}
             onChange={this.handleAmplitudeChange.bind(this)}
           />
-          <br></br>
           width
           <Slider
             min={minPeriodWidth}
             max={maxPeriodWidth}
             onChange={this.handleWidthChange.bind(this)}
+          />
+          cycles
+          <Slider
+            min={1}
+            max={15}
+            onChange={this.handleCyclesChange.bind(this)}
           />
         </div>
         <div className="data-pane">


### PR DESCRIPTION
# Summary
This change allows for multiple cycles of an SVG `path` to be drawn by the `SVGWave`.

As with other states, the numCycles is hooked up to another `rc-slider`.
![image](https://user-images.githubusercontent.com/11576884/52160424-fb3cd400-2669-11e9-99d6-59e3d473e6fb.png)
  