### PR TITLE
Decouple Width

### DIFF
--- a/src/SVGWave.jsx
+++ b/src/SVGWave.jsx
@@ -4,12 +4,11 @@ import './SVGWave.css'
 class SVGWave extends Component {
 
   render() {
-    const svgContentPadding = 10;
     const amplitude = this.props.amplitude;
-    const height = amplitude * 2 + svgContentPadding;
     const periodWidth = this.props.periodWidth;
     const strokeWidth = this.props.strokeWidth;
-    const width = (periodWidth * (this.props.numCycles - 2)) + svgContentPadding;
+    const height = this.props.height;
+    const width = this.props.width;
     const startX = 0;
     const startY = height / 2;
 
@@ -108,6 +107,7 @@ class SVGWave extends Component {
       <div className="container">
         <div className="content-pane">
           <svg height={height} width={width}>
+            <rect height={height} width={width} style={{stroke: "grey"}} fillOpacity={0.0}/>
             <g className="wave">
               <path
                 d={dProp}

--- a/src/SVGWaveController.jsx
+++ b/src/SVGWaveController.jsx
@@ -9,8 +9,12 @@ const minPeriodWidth = 50;
 const maxPeriodWidth = 150;
 const minAmplitude = 50;
 const maxAmplitude = 150;
-const minCycles = 3;
-const maxCycles = 7;
+const minCycles = 2;
+const maxCycles = 20;
+const minHeight = 25;
+const maxHeight = 200;
+const minWidth = 25;
+const maxWidth = 400;
 
 class SVGWaveController extends Component {
   constructor(props) {
@@ -21,6 +25,8 @@ class SVGWaveController extends Component {
       periodWidth: minPeriodWidth,
       amplitude: minAmplitude,
       numCycles: minCycles,
+      height: minHeight,
+      width: minWidth,
     };
   }
 
@@ -33,6 +39,8 @@ class SVGWaveController extends Component {
   render() {
     const wave = (
       <SVGWave
+        height={this.state.height}
+        width={this.state.width}
         showDebug={true}
         strokeWidth={this.state.strokeWidth}
         periodWidth={this.state.periodWidth}
@@ -50,6 +58,8 @@ class SVGWaveController extends Component {
           periodWidth: minPeriodWidth,
           amplitude: minAmplitude,
           numCycles: minCycles,
+          height: minHeight,
+          width: minWidth,
         }}
 
         maxes={{
@@ -57,6 +67,8 @@ class SVGWaveController extends Component {
           periodWidth: maxPeriodWidth,
           amplitude: maxAmplitude,
           numCycles: maxCycles,
+          height: maxHeight,
+          width: maxWidth,
         }}
 
         onChange={this.onChange.bind(this)}


### PR DESCRIPTION
# Summary 
This resolves https://github.com/seanhaneberg/svg-experiments/issues/14. Users can now adjust the width and height of the `SVGWave` component. 

![image](https://user-images.githubusercontent.com/11576884/52457141-3a0cd700-2b0d-11e9-963d-c0f59894816f.png)
