### PR TITLE
Support Boolean Properties in Component Monitor

### DIFF
--- a/src/ComponentMonitor.jsx
+++ b/src/ComponentMonitor.jsx
@@ -3,14 +3,37 @@ import MetadataSliders from './MetadataSliders';
 import './ComponentMonitor.css'
 
 class ComponentMonitor extends Component {
+
   render() {
+
+    let sliderProps = {};
+    let checkboxProps = {};
+
+    Object.keys(this.props.subject.props).map((fieldName) => {
+      const val = this.props.subject.props[fieldName];
+      const type = (typeof val);
+      switch (type) {
+        case "number":
+          sliderProps[fieldName] = val;
+          break;
+        case "boolean":
+          checkboxProps[fieldName] = val;
+          break;
+        default:
+          // Ignore unknown types
+          break;
+      }
+      return null;
+    });
+
+
     return (
       <div className="container">
         <div className="slider-pane">
           <MetadataSliders
             title="props"
             onChange={this.props.onChange}
-            metadata={this.props.subject.props}
+            metadata={sliderProps}
             mins={this.props.mins}
             maxes={this.props.maxes}
           />

--- a/src/ComponentMonitor.jsx
+++ b/src/ComponentMonitor.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import MetadataSliders from './MetadataSliders';
 import './ComponentMonitor.css'
+import MetadataCheckboxes from './MetadataCheckboxes';
 
 class ComponentMonitor extends Component {
 
@@ -26,7 +27,6 @@ class ComponentMonitor extends Component {
       return null;
     });
 
-
     return (
       <div className="container">
         <div className="slider-pane">
@@ -38,6 +38,10 @@ class ComponentMonitor extends Component {
             maxes={this.props.maxes}
           />
         </div>
+        <MetadataCheckboxes
+          onChange={this.props.onChange}
+          metadata={checkboxProps}
+        />
       </div>
     );
   }

--- a/src/ComponentMonitor.jsx
+++ b/src/ComponentMonitor.jsx
@@ -3,18 +3,6 @@ import MetadataSliders from './MetadataSliders';
 import './ComponentMonitor.css'
 
 class ComponentMonitor extends Component {
-  constructor(props) {
-    super(props);
-
-    const subjectProps = this.props.subject.props;
-    const propKeys = subjectProps ? Object.keys(subjectProps) : [];
-    const initialState = {};
-    propKeys.map((val, index) => {
-      return initialState[index] = val;
-    });
-    this.state = { initialState };
-  }
-
   render() {
     return (
       <div className="container">

--- a/src/MetadataCheckboxes.css
+++ b/src/MetadataCheckboxes.css
@@ -1,0 +1,11 @@
+.metadata-item {
+  text-align: left;
+  color: #777777;
+  font-size: 12px;
+}
+
+.metadata-title {
+  text-align: center;
+  color: #777777;
+  font-size: 14px;
+}

--- a/src/MetadataCheckboxes.jsx
+++ b/src/MetadataCheckboxes.jsx
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import './MetadataCheckboxes.css';
+
+class MetadataCheckboxes extends Component {
+
+  onChange(fieldName, oldVal, newVal) {
+    return this.props.onChange(fieldName, oldVal, newVal);
+  }
+
+  render() {
+    // Process all fields on the metadata object
+    const metadata = this.props.metadata ? this.props.metadata : {};
+    const items = Object.keys(metadata).map((fieldName, index) => {
+      const curFieldVal = metadata[fieldName];
+      return (
+        <div key={index}>
+          {fieldName}
+          <input
+            type="checkbox"
+            onChange={() => {
+              this.onChange(fieldName, curFieldVal, !curFieldVal);
+            }}
+            checked={curFieldVal}
+          />
+        </div>
+      );
+    });
+
+
+    return (
+      <div>
+        <div className="metadata-item">{items}</div>
+      </div>
+    );
+  }
+}
+
+export default MetadataCheckboxes;

--- a/src/SVGWave.jsx
+++ b/src/SVGWave.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import './SVGWave.css'
 
 class SVGWave extends Component {
-
   render() {
     const amplitude = this.props.amplitude;
     const periodWidth = this.props.periodWidth;

--- a/src/SVGWaveController.jsx
+++ b/src/SVGWaveController.jsx
@@ -11,9 +11,9 @@ const minAmplitude = 50;
 const maxAmplitude = 150;
 const minCycles = 2;
 const maxCycles = 20;
-const minHeight = 25;
+const minHeight = 75;
 const maxHeight = 200;
-const minWidth = 25;
+const minWidth = 75;
 const maxWidth = 400;
 
 class SVGWaveController extends Component {

--- a/src/SVGWaveController.jsx
+++ b/src/SVGWaveController.jsx
@@ -27,6 +27,7 @@ class SVGWaveController extends Component {
       numCycles: minCycles,
       height: minHeight,
       width: minWidth,
+      showDebug: false,
     };
   }
 
@@ -41,7 +42,7 @@ class SVGWaveController extends Component {
       <SVGWave
         height={this.state.height}
         width={this.state.width}
-        showDebug={true}
+        showDebug={this.state.showDebug}
         strokeWidth={this.state.strokeWidth}
         periodWidth={this.state.periodWidth}
         amplitude={this.state.amplitude}


### PR DESCRIPTION
# Summary 
This resolves #19. Now, we only pass `number` properties to the `MetadataSliders` component. 
Moreover, a new `MetadataCheckboxes` component receives a list of `boolean` components.


![image](https://user-images.githubusercontent.com/11576884/52515739-5fb0e380-2bd4-11e9-8325-732cf48cc9f6.png)
![image](https://user-images.githubusercontent.com/11576884/52515741-650e2e00-2bd4-11e9-9965-5eb692294141.png)
